### PR TITLE
fix: makes use of a test portal-tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG MP_VERSION=v3.1.0
 ARG ADDONS_TAG=main
-ARG PORTAL_TAG=main
+ARG PORTAL_TAG=local-test
 # TODO: readd this argument
 #ARG PORTAL_NAME=simulation
 


### PR DESCRIPTION
This MR changes the Portal-Tag to the one where the main work is done temporaly. Once the local-test branch is merged, this MR should be reverted.